### PR TITLE
[BTAT-3470] Add forward routing for the service

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -48,4 +48,6 @@ object ConfigKeys {
   val manageVatSubscriptionFrontendHost: String = "manage-vat-subscription-frontend.host"
   val manageVatSubscriptionFrontendUrl: String = "manage-vat-subscription-frontend.url"
 
+  val deregThreshold: String = "thresholds.deregistrationThreshold"
+
 }

--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -44,6 +44,7 @@ trait AppConfig extends ServicesConfig {
   val clientServicesGovUkGuidance: String
   val govUkCancelVatRegistration: String
   val manageVatSubscriptionFrontendUrl: String
+  val deregThreshold: Int
   val features: Features
 }
 
@@ -91,6 +92,8 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, envir
   override lazy val clientServicesGovUkGuidance:String = getString(Keys.govUkSetupClientServices)
 
   override lazy val govUkCancelVatRegistration: String = getString(Keys.govUkCancelVatRegistration)
+
+  override lazy val deregThreshold: Int = getInt(Keys.deregThreshold)
 
   override val features = new Features(runModeConfiguration)
 }

--- a/app/controllers/CapitalAssetsController.scala
+++ b/app/controllers/CapitalAssetsController.scala
@@ -20,6 +20,7 @@ import config.AppConfig
 import controllers.predicates.AuthPredicate
 import forms.YesNoForm
 import javax.inject.{Inject, Singleton}
+import models.{No, Yes}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -38,7 +39,10 @@ class CapitalAssetsController @Inject()(val messagesApi: MessagesApi,
   val submit: Action[AnyContent] = authentication.async { implicit user =>
     YesNoForm.yesNoForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.capitalAssets(error))),
-      _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      {
+        case Yes => Future.successful(Redirect(controllers.routes.SellCapitalAssetsController.show()))
+        case No => Future.successful(Redirect(controllers.routes.OptionOwesMoneyController.show()))
+      }
     )
   }
 }

--- a/app/controllers/CeasedTradingDateController.scala
+++ b/app/controllers/CeasedTradingDateController.scala
@@ -39,7 +39,7 @@ class CeasedTradingDateController @Inject()(val messagesApi: MessagesApi,
 
     CeasedTradingDateForm.ceasedTradingDateForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.ceasedTradingDate(error))),
-      _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      _ => Future.successful(Redirect(controllers.routes.VATAccountsController.show()))
     )
   }
 }

--- a/app/controllers/DeregistrationPropertyController.scala
+++ b/app/controllers/DeregistrationPropertyController.scala
@@ -42,8 +42,8 @@ class DeregistrationPropertyController @Inject()(val messagesApi: MessagesApi,
     YesNoForm.yesNoForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.deregistrationProperty(error))),
       {
-        case Yes => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
-        case No => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+        case Yes => Future.successful(Redirect(controllers.routes.OptionTaxController.show()))
+        case No => Future.successful(Redirect(controllers.routes.CapitalAssetsController.show()))
       }
     )
   }

--- a/app/controllers/DeregistrationReasonController.scala
+++ b/app/controllers/DeregistrationReasonController.scala
@@ -20,6 +20,7 @@ import javax.inject.{Inject, Singleton}
 import config.AppConfig
 import controllers.predicates.AuthPredicate
 import forms.DeregistrationReasonForm
+import models.{BelowThreshold, Ceased, Other}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -39,11 +40,11 @@ class DeregistrationReasonController @Inject()(val messagesApi: MessagesApi,
 
     DeregistrationReasonForm.deregistrationReasonForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.deregistrationReason(error))),
-      success =>
-        success.reason match {
-          case "other" => Future.successful(Redirect(appConfig.govUkCancelVatRegistration))
-          case _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
-        }
+      {
+        case Ceased => Future.successful(Redirect(controllers.routes.CeasedTradingDateController.show()))
+        case BelowThreshold => Future.successful(Redirect(controllers.routes.TaxableTurnoverController.show()))
+        case Other => Future.successful(Redirect(appConfig.govUkCancelVatRegistration))
+      }
     )
   }
 }

--- a/app/controllers/NextTaxableTurnoverController.scala
+++ b/app/controllers/NextTaxableTurnoverController.scala
@@ -39,7 +39,12 @@ class NextTaxableTurnoverController @Inject()(val messagesApi: MessagesApi,
 
     TaxableTurnoverForm.taxableTurnoverForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.nextTaxableTurnover(error))),
-      _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      {
+        case success if success.turnover >= appConfig.deregThreshold =>
+          Future.successful(Redirect(controllers.routes.CannotDeregisterThresholdController.show()))
+        case _ =>
+          Future.successful(Redirect(controllers.routes.WhyTurnoverBelowController.show()))
+      }
     )
   }
 

--- a/app/controllers/OptionOwesMoneyController.scala
+++ b/app/controllers/OptionOwesMoneyController.scala
@@ -39,7 +39,7 @@ class OptionOwesMoneyController @Inject()(val messagesApi: MessagesApi,
 
     YesNoForm.yesNoForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.optionOwesMoney(error))),
-      success => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      _ => Future.successful(Redirect(controllers.routes.DeregistrationDateController.show()))
     )
   }
 }

--- a/app/controllers/OptionOwesMoneyController.scala
+++ b/app/controllers/OptionOwesMoneyController.scala
@@ -39,7 +39,9 @@ class OptionOwesMoneyController @Inject()(val messagesApi: MessagesApi,
 
     YesNoForm.yesNoForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.optionOwesMoney(error))),
-      _ => Future.successful(Redirect(controllers.routes.DeregistrationDateController.show()))
+      _ =>
+        //TODO: In future, this routing will need to be dependent on previous stored answers, for now it is always shown
+        Future.successful(Redirect(controllers.routes.DeregistrationDateController.show()))
     )
   }
 }

--- a/app/controllers/OptionTaxController.scala
+++ b/app/controllers/OptionTaxController.scala
@@ -39,7 +39,7 @@ class OptionTaxController @Inject()(val messagesApi: MessagesApi,
 
     YesNoForm.yesNoForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.optionTax(error))),
-      success => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      _ => Future.successful(Redirect(controllers.routes.CapitalAssetsController.show()))
     )
   }
 }

--- a/app/controllers/SellCapitalAssetsController.scala
+++ b/app/controllers/SellCapitalAssetsController.scala
@@ -40,7 +40,7 @@ class SellCapitalAssetsController @Inject()(val messagesApi: MessagesApi,
 
     YesNoForm.yesNoForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.sellCapitalAssets(error))),
-      success => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      _ => Future.successful(Redirect(controllers.routes.OptionOwesMoneyController.show()))
     )
   }
 }

--- a/app/controllers/TaxableTurnoverController.scala
+++ b/app/controllers/TaxableTurnoverController.scala
@@ -39,7 +39,12 @@ class TaxableTurnoverController @Inject()(val messagesApi: MessagesApi,
 
     TaxableTurnoverForm.taxableTurnoverForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.taxableTurnover(error))),
-       _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      {
+        case success if success.turnover >= appConfig.deregThreshold =>
+          Future.successful(Redirect(controllers.routes.NextTaxableTurnoverController.show()))
+        case _ =>
+          Future.successful(Redirect(controllers.routes.VATAccountsController.show()))
+      }
     )
   }
 

--- a/app/controllers/VATAccountsController.scala
+++ b/app/controllers/VATAccountsController.scala
@@ -38,7 +38,7 @@ class VATAccountsController @Inject()(val messagesApi: MessagesApi,
 
     VATAccountsForm.vatAccountsForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.vatAccounts(error))),
-      _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      _ => Future.successful(Redirect(controllers.routes.DeregistrationPropertyController.show()))
     )
   }
 

--- a/app/controllers/WhyTurnoverBelowController.scala
+++ b/app/controllers/WhyTurnoverBelowController.scala
@@ -38,7 +38,7 @@ class WhyTurnoverBelowController @Inject()(val messagesApi: MessagesApi,
   val submit: Action[AnyContent] = authenticate.async { implicit user =>
     WhyTurnoverBelowForm.whyTurnoverBelowForm.bindFromRequest().fold(
       error => Future.successful(BadRequest(views.html.whyTurnoverBelow(error))),
-      _ => Future.successful(Redirect(controllers.routes.HelloWorldController.helloWorld()))
+      _ => Future.successful(Redirect(controllers.routes.VATAccountsController.show()))
     )
   }
 }

--- a/app/forms/DeregistrationReasonForm.scala
+++ b/app/forms/DeregistrationReasonForm.scala
@@ -16,16 +16,43 @@
 
 package forms
 
-import models.DeregistrationReasonModel
-import play.api.data.Form
+import models._
+import play.api.data.{Form, FormError}
 import play.api.data.Forms._
+import play.api.data.format.Formatter
 
 object DeregistrationReasonForm {
 
-  val deregistrationReasonForm: Form[DeregistrationReasonModel] = Form(
-    mapping(
-      "reason" -> nonEmptyText
-    )(DeregistrationReasonModel.apply)(DeregistrationReasonModel.unapply)
-  )
+  val reason: String = "reason"
+  val ceased: String = "stoppedTrading"
+  val belowThreshold: String = "turnoverBelowThreshold"
+  val other: String = "other"
 
+  val error: String = "common.error.mandatoryRadioOption"
+
+  private val formatter: Formatter[DeregistrationReason] = new Formatter[DeregistrationReason] {
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], DeregistrationReason] = {
+      data.get(key) match {
+        case Some(`ceased`) => Right(Ceased)
+        case Some(`belowThreshold`) => Right(BelowThreshold)
+        case Some(`other`) => Right(Other)
+        case _ => Left(Seq(FormError(key, error)))
+      }
+    }
+
+    override def unbind(key: String, value: DeregistrationReason): Map[String, String] = {
+      val stringValue = value match {
+        case Ceased => ceased
+        case BelowThreshold => belowThreshold
+        case Other => other
+      }
+      Map(key -> stringValue)
+    }
+  }
+
+  val deregistrationReasonForm: Form[DeregistrationReason] = Form(
+    single(
+      reason -> of(formatter)
+    )
+  )
 }

--- a/app/models/DeregistrationReason.scala
+++ b/app/models/DeregistrationReason.scala
@@ -16,10 +16,8 @@
 
 package models
 
-import play.api.libs.json.{Json, OFormat}
+sealed trait DeregistrationReason
 
-case class DeregistrationReasonModel(reason: String)
-
-object DeregistrationReasonModel {
-  implicit val format: OFormat[DeregistrationReasonModel] = Json.format[DeregistrationReasonModel]
-}
+object Ceased extends DeregistrationReason
+object BelowThreshold extends DeregistrationReason
+object Other extends DeregistrationReason

--- a/app/views/cannotDeregisterThreshold.scala.html
+++ b/app/views/cannotDeregisterThreshold.scala.html
@@ -26,7 +26,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.NextTaxableTurnoverController.show().url">@messages("common.back")</a>
 
     @headings(messages("cannotDeregister.title"))
 

--- a/app/views/capitalAssets.scala.html
+++ b/app/views/capitalAssets.scala.html
@@ -28,6 +28,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
+    <!--TODO: Update this as part of the back linking story as the redirect is dynamic-->
     <a class="link-back" href="#">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)

--- a/app/views/ceasedTradingDate.scala.html
+++ b/app/views/ceasedTradingDate.scala.html
@@ -26,7 +26,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.DeregistrationReasonController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form, Some("ceasedTrading"))
 

--- a/app/views/deregisterForVAT.scala.html
+++ b/app/views/deregisterForVAT.scala.html
@@ -24,7 +24,7 @@ title = messages("deregisterForVAT.title"),
 bodyClasses = None,
 appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@appConfig.manageVatSubscriptionFrontendUrl">@messages("common.back")</a>
 
     @headings(messages("deregisterForVAT.title"))
 

--- a/app/views/deregistrationProperty.scala.html
+++ b/app/views/deregistrationProperty.scala.html
@@ -27,7 +27,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.VATAccountsController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/deregistrationReason.scala.html
+++ b/app/views/deregistrationReason.scala.html
@@ -28,7 +28,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.DeregisterForVATController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/deregistrationReason.scala.html
+++ b/app/views/deregistrationReason.scala.html
@@ -18,9 +18,10 @@
 @import views.html.templates.errors.errorSummary
 @import templates.headings
 @import views.html.templates.inputs.radioHelper
+@import forms.DeregistrationReasonForm._
 
 
-@(form: Form[DeregistrationReasonModel])(implicit user : User[_], messages: Messages, appConfig: config.AppConfig)
+@(form: Form[DeregistrationReason])(implicit user : User[_], messages: Messages, appConfig: config.AppConfig)
 
 @views.html.main_template(
     title = messages("deregistrationReason.title"),
@@ -39,9 +40,9 @@
             @radioHelper(
                 field = form("reason"),
                 choices = Seq(
-                    ("stoppedTrading", Messages("deregistrationReason.reason.stoppedTrading")),
-                    ("turnoverBelowThreshold", Messages("deregistrationReason.reason.turnoverBelowThreshold")),
-                    ("other", Messages("deregistrationReason.reason.other"))
+                    (ceased, Messages("deregistrationReason.reason.stoppedTrading")),
+                    (belowThreshold, Messages("deregistrationReason.reason.turnoverBelowThreshold")),
+                    (other, Messages("deregistrationReason.reason.other"))
                 ),
                 question = Messages("deregistrationReason.title")
             )

--- a/app/views/nextTaxableTurnover.scala.html
+++ b/app/views/nextTaxableTurnover.scala.html
@@ -27,7 +27,7 @@ title = messages("nextTaxableTurnover.title"),
 bodyClasses = None,
 appConfig = appConfig) {
 
-<a class="link-back" href="#">@messages("common.back")</a>
+<a class="link-back" href="@controllers.routes.TaxableTurnoverController.show().url">@messages("common.back")</a>
 
 @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/optionOwesMoney.scala.html
+++ b/app/views/optionOwesMoney.scala.html
@@ -28,6 +28,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
+    <!--TODO: Update this as part of the back linking story as the redirect is dynamic-->
     <a class="link-back" href="#">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)

--- a/app/views/optionTax.scala.html
+++ b/app/views/optionTax.scala.html
@@ -28,7 +28,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.DeregistrationPropertyController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/sellCapitalAssets.scala.html
+++ b/app/views/sellCapitalAssets.scala.html
@@ -28,7 +28,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.CapitalAssetsController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/taxableTurnover.scala.html
+++ b/app/views/taxableTurnover.scala.html
@@ -27,7 +27,7 @@ title = messages("taxableTurnover.title"),
 bodyClasses = None,
 appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.DeregistrationReasonController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/vatAccounts.scala.html
+++ b/app/views/vatAccounts.scala.html
@@ -31,7 +31,8 @@
   bodyClasses = None,
   appConfig = appConfig) {
 
-    <a class="link-back" href="@controllers.routes.CeasedTradingDateController.show().url">@messages("common.back")</a>
+    <!--TODO: Back link is dynamic, needs to be updated as part of the back linking story-->
+    <a class="link-back" href="#">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/vatAccounts.scala.html
+++ b/app/views/vatAccounts.scala.html
@@ -31,7 +31,7 @@
   bodyClasses = None,
   appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.CeasedTradingDateController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form)
 

--- a/app/views/whyTurnoverBelow.scala.html
+++ b/app/views/whyTurnoverBelow.scala.html
@@ -26,7 +26,7 @@
     bodyClasses = None,
     appConfig = appConfig) {
 
-    <a class="link-back" href="#">@messages("common.back")</a>
+    <a class="link-back" href="@controllers.routes.NextTaxableTurnoverController.show().url">@messages("common.back")</a>
 
     @errorSummary("common.errorSummary.heading", form, Some("reason"))
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,3 +131,7 @@ whitelist {
 government-gateway {
   host = "http://localhost:9025"
 }
+
+thresholds {
+  deregistrationThreshold = 83000
+}

--- a/it/pages/WhyTurnoverBelowISpec.scala
+++ b/it/pages/WhyTurnoverBelowISpec.scala
@@ -95,9 +95,7 @@ class WhyTurnoverBelowISpec extends IntegrationBaseSpec {
 
           response should have(
             httpStatus(SEE_OTHER),
-
-            //TODO: Redirect needs updating as part of the routing Sub-Task
-            redirectURI(controllers.routes.HelloWorldController.helloWorld().url)
+            redirectURI(controllers.routes.VATAccountsController.show().url)
           )
         }
       }

--- a/test/controllers/CapitalAssetsControllerSpec.scala
+++ b/test/controllers/CapitalAssetsControllerSpec.scala
@@ -78,9 +78,8 @@ class CapitalAssetsControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be update as part of the routing sub-task
-        "redirect to the HelloWorld controller" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to '${controllers.routes.SellCapitalAssetsController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.SellCapitalAssetsController.show().url)
         }
       }
 
@@ -95,9 +94,8 @@ class CapitalAssetsControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be update as part of the routing sub-task
-        "redirect to the HelloWorld controller" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to '${controllers.routes.OptionOwesMoneyController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.OptionOwesMoneyController.show().url)
         }
       }
 

--- a/test/controllers/CeasedTradingDateControllerSpec.scala
+++ b/test/controllers/CeasedTradingDateControllerSpec.scala
@@ -81,9 +81,8 @@ class CeasedTradingDateControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"redirect to the ${controllers.routes.HelloWorldController.helloWorld().url}" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to the ${controllers.routes.VATAccountsController.show().url}" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.VATAccountsController.show().url)
         }
       }
 

--- a/test/controllers/DeregistrationPropertyControllerSpec.scala
+++ b/test/controllers/DeregistrationPropertyControllerSpec.scala
@@ -65,6 +65,10 @@ class DeregistrationPropertyControllerSpec extends ControllerBaseSpec {
           mockAuthResult(Future.successful(mockAuthorisedIndividual))
           status(result) shouldBe Status.SEE_OTHER
         }
+
+        s"Redirect to '${controllers.routes.OptionTaxController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.OptionTaxController.show().url)
+        }
       }
 
       "the user submits after selecting a 'No' option" should {
@@ -76,6 +80,10 @@ class DeregistrationPropertyControllerSpec extends ControllerBaseSpec {
         "return 303 (SEE OTHER)" in {
           mockAuthResult(Future.successful(mockAuthorisedIndividual))
           status(result) shouldBe Status.SEE_OTHER
+        }
+
+        s"Redirect to '${controllers.routes.CapitalAssetsController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.CapitalAssetsController.show().url)
         }
       }
 

--- a/test/controllers/DeregistrationReasonControllerSpec.scala
+++ b/test/controllers/DeregistrationReasonControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import forms.DeregistrationReasonForm._
 import play.api.http.Status
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeRequest
@@ -54,7 +55,7 @@ class DeregistrationReasonControllerSpec extends ControllerBaseSpec {
       "the user submits after selecting an 'stoppedTrading' option" should {
 
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest("POST", "/").withFormUrlEncodedBody(("reason", "stoppedTrading"))
+          FakeRequest("POST", "/").withFormUrlEncodedBody((reason, ceased))
         lazy val result = TestDeregistrationReasonController.submit()(request)
 
         "return 303 (SEE OTHER)" in {
@@ -62,16 +63,15 @@ class DeregistrationReasonControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This test needs updating as part of the routing story
-        s"redirect to ${controllers.routes.HelloWorldController.helloWorld().url}" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to ${controllers.routes.CeasedTradingDateController.show().url}" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.CeasedTradingDateController.show().url)
         }
       }
 
       "the user submits after selecting the 'turnoverBelowThreshold' option" should {
 
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest("POST", "/").withFormUrlEncodedBody(("reason", "turnoverBelowThreshold"))
+          FakeRequest("POST", "/").withFormUrlEncodedBody((reason, "turnoverBelowThreshold"))
         lazy val result = TestDeregistrationReasonController.submit()(request)
 
 
@@ -80,16 +80,15 @@ class DeregistrationReasonControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This test needs updating as part of the routing story
-        s"redirect to ${controllers.routes.HelloWorldController.helloWorld().url}" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to ${controllers.routes.TaxableTurnoverController.show().url}" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.TaxableTurnoverController.show().url)
         }
       }
 
       "the user submits after selecting the 'other' option" should {
 
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest("POST", "/").withFormUrlEncodedBody(("reason", "other"))
+          FakeRequest("POST", "/").withFormUrlEncodedBody((reason, other))
         lazy val result = TestDeregistrationReasonController.submit()(request)
 
         "return 303 (SEE OTHER)" in {
@@ -105,7 +104,7 @@ class DeregistrationReasonControllerSpec extends ControllerBaseSpec {
       "the user submits without selecting an option" should {
 
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest("POST", "/").withFormUrlEncodedBody(("reason", ""))
+          FakeRequest("POST", "/").withFormUrlEncodedBody((reason, ""))
         lazy val result = TestDeregistrationReasonController.submit()(request)
 
         "return 400 (BAD REQUEST)" in {
@@ -120,6 +119,6 @@ class DeregistrationReasonControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    authChecks(".submit", TestDeregistrationReasonController.submit(), FakeRequest("POST", "/").withFormUrlEncodedBody(("reason", "other")))
+    authChecks(".submit", TestDeregistrationReasonController.submit(), FakeRequest("POST", "/").withFormUrlEncodedBody((reason, other)))
   }
 }

--- a/test/controllers/NextTaxableTurnoverControllerSpec.scala
+++ b/test/controllers/NextTaxableTurnoverControllerSpec.scala
@@ -67,10 +67,10 @@ class NextTaxableTurnoverControllerSpec extends ControllerBaseSpec {
 
     "Calling the .submit action" when {
 
-      "the user submits after inputting an amount" should {
+      "the user submits after inputting an amount that is equal to the threshold" should {
 
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", "1000.01"))
+          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", mockConfig.deregThreshold.toString))
         lazy val result = TestNextTaxableTurnoverController.submit()(request)
 
         "return 303 (SEE OTHER)" in {
@@ -78,9 +78,40 @@ class NextTaxableTurnoverControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.CannotDeregisterThresholdController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.CannotDeregisterThresholdController.show().url)
+        }
+      }
+
+      "the user submits after inputting an amount that is greater than the threshold" should {
+
+        lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", (mockConfig.deregThreshold + 0.01).toString))
+        lazy val result = TestNextTaxableTurnoverController.submit()(request)
+
+        "return 303 (SEE OTHER)" in {
+          mockAuthResult(Future.successful(mockAuthorisedIndividual))
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        s"Redirect to the '${controllers.routes.CannotDeregisterThresholdController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.CannotDeregisterThresholdController.show().url)
+        }
+      }
+
+      "the user submits after inputting an amount that is less than the threshold" should {
+
+        lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", (mockConfig.deregThreshold - 0.01).toString))
+        lazy val result = TestNextTaxableTurnoverController.submit()(request)
+
+        "return 303 (SEE OTHER)" in {
+          mockAuthResult(Future.successful(mockAuthorisedIndividual))
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        s"Redirect to the '${controllers.routes.WhyTurnoverBelowController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.WhyTurnoverBelowController.show().url)
         }
       }
 

--- a/test/controllers/OptionOwesMoneyControllerSpec.scala
+++ b/test/controllers/OptionOwesMoneyControllerSpec.scala
@@ -77,9 +77,8 @@ class OptionOwesMoneyControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.DeregistrationDateController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.DeregistrationDateController.show().url)
         }
       }
 
@@ -94,9 +93,8 @@ class OptionOwesMoneyControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.DeregistrationDateController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.DeregistrationDateController.show().url)
         }
       }
 

--- a/test/controllers/OptionTaxControllerSpec.scala
+++ b/test/controllers/OptionTaxControllerSpec.scala
@@ -62,9 +62,8 @@ class OptionTaxControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to '${controllers.routes.CapitalAssetsController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.CapitalAssetsController.show().url)
         }
       }
 
@@ -79,9 +78,8 @@ class OptionTaxControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to '${controllers.routes.CapitalAssetsController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.CapitalAssetsController.show().url)
         }
       }
 

--- a/test/controllers/SellCapitalAssetsControllerSpec.scala
+++ b/test/controllers/SellCapitalAssetsControllerSpec.scala
@@ -62,9 +62,8 @@ class SellCapitalAssetsControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.OptionOwesMoneyController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.OptionOwesMoneyController.show().url)
         }
       }
 
@@ -79,9 +78,8 @@ class SellCapitalAssetsControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.OptionOwesMoneyController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.OptionOwesMoneyController.show().url)
         }
       }
 

--- a/test/controllers/TaxableTurnoverControllerSpec.scala
+++ b/test/controllers/TaxableTurnoverControllerSpec.scala
@@ -67,10 +67,10 @@ class TaxableTurnoverControllerSpec extends ControllerBaseSpec {
 
     "Calling the .submit action" when {
 
-      "the user submits after inputting an amount" should {
+      "the user submits after inputting an amount which is equal to the threshold" should {
 
         lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
-          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", "1000.01"))
+          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", mockConfig.deregThreshold.toString))
         lazy val result = TestTaxableTurnoverController.submit()(request)
 
         "return 303 (SEE OTHER)" in {
@@ -78,9 +78,40 @@ class TaxableTurnoverControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.NextTaxableTurnoverController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.NextTaxableTurnoverController.show().url)
+        }
+      }
+
+      "the user submits after inputting an amount which is greater than the threshold" should {
+
+        lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", (mockConfig.deregThreshold + 0.01).toString))
+        lazy val result = TestTaxableTurnoverController.submit()(request)
+
+        "return 303 (SEE OTHER)" in {
+          mockAuthResult(Future.successful(mockAuthorisedIndividual))
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        s"Redirect to the '${controllers.routes.NextTaxableTurnoverController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.NextTaxableTurnoverController.show().url)
+        }
+      }
+
+      "the user submits after inputting an amount which is less than the threshold" should {
+
+        lazy val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+          FakeRequest("POST", "/").withFormUrlEncodedBody(("turnover", (mockConfig.deregThreshold - 0.01).toString))
+        lazy val result = TestTaxableTurnoverController.submit()(request)
+
+        "return 303 (SEE OTHER)" in {
+          mockAuthResult(Future.successful(mockAuthorisedIndividual))
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        s"Redirect to the '${controllers.routes.VATAccountsController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.VATAccountsController.show().url)
         }
       }
 

--- a/test/controllers/VATAccountsControllerSpec.scala
+++ b/test/controllers/VATAccountsControllerSpec.scala
@@ -74,9 +74,8 @@ class VATAccountsControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.DeregistrationPropertyController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.DeregistrationPropertyController.show().url)
         }
       }
 
@@ -91,9 +90,8 @@ class VATAccountsControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This needs to be updated as part of the routing sub-task
-        s"Redirect to the '${controllers.routes.HelloWorldController.helloWorld().url}'" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"Redirect to the '${controllers.routes.DeregistrationPropertyController.show().url}'" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.DeregistrationPropertyController.show().url)
         }
       }
 

--- a/test/controllers/WhyTurnoverBelowControllerSpec.scala
+++ b/test/controllers/WhyTurnoverBelowControllerSpec.scala
@@ -80,9 +80,8 @@ class WhyTurnoverBelowControllerSpec extends ControllerBaseSpec {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        //TODO: This test needs updating as part of the routing story
-        s"redirect to ${controllers.routes.HelloWorldController.helloWorld().url}" in {
-          redirectLocation(result) shouldBe Some(controllers.routes.HelloWorldController.helloWorld().url)
+        s"redirect to ${controllers.routes.VATAccountsController.show().url}" in {
+          redirectLocation(result) shouldBe Some(controllers.routes.VATAccountsController.show().url)
         }
       }
 

--- a/test/forms/DeregistrationReasonFormSpec.scala
+++ b/test/forms/DeregistrationReasonFormSpec.scala
@@ -16,14 +16,14 @@
 
 package forms
 
-import models.DeregistrationReasonModel
+import models.Other
 import uk.gov.hmrc.play.test.UnitSpec
 
 class DeregistrationReasonFormSpec extends UnitSpec {
 
   "Binding a form with valid data" should {
 
-    val data = Map("reason" -> "Reason")
+    val data = Map(DeregistrationReasonForm.reason -> DeregistrationReasonForm.other)
     val form = DeregistrationReasonForm.deregistrationReasonForm.bind(data)
 
     "result in a form with no errors" in {
@@ -31,7 +31,7 @@ class DeregistrationReasonFormSpec extends UnitSpec {
     }
 
     "generate the correct model" in {
-      form.value shouldBe Some(DeregistrationReasonModel("Reason"))
+      form.value shouldBe Some(Other)
     }
   }
 
@@ -55,9 +55,8 @@ class DeregistrationReasonFormSpec extends UnitSpec {
   "A form built from a valid model" should {
 
     "generate the correct mapping" in {
-      val model = DeregistrationReasonModel("Another Reason")
-      val form = DeregistrationReasonForm.deregistrationReasonForm.fill(model)
-      form.data shouldBe Map("reason" -> "Another Reason")
+      val form = DeregistrationReasonForm.deregistrationReasonForm.fill(Other)
+      form.data shouldBe Map(DeregistrationReasonForm.reason -> DeregistrationReasonForm.other)
     }
   }
 

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -39,6 +39,7 @@ class MockAppConfig(val runModeConfiguration: Configuration, val mode: Mode = Mo
   override val surveyUrl: String = "/some-survey-url"
   override val unauthorisedSignOutUrl: String = ""
   override val manageVatSubscriptionFrontendUrl: String = "http://localhost:9150/vat-through-software/account/change-business-details"
+  override val deregThreshold: Int = 83000
 
   override val features: Features = new Features(runModeConfiguration)
 }

--- a/test/views/CannotDeregisterThresholdSpec.scala
+++ b/test/views/CannotDeregisterThresholdSpec.scala
@@ -42,7 +42,7 @@ class CannotDeregisterThresholdSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.NextTaxableTurnoverController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/CeasedTradingDateSpec.scala
+++ b/test/views/CeasedTradingDateSpec.scala
@@ -45,7 +45,7 @@ class CeasedTradingDateSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregistrationReasonController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/DeregisterForVATSpec.scala
+++ b/test/views/DeregisterForVATSpec.scala
@@ -39,7 +39,7 @@ class DeregisterForVATSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe mockConfig.manageVatSubscriptionFrontendUrl
     }
 
     s"have the correct page heading" in {

--- a/test/views/DeregistrationPropertySpec.scala
+++ b/test/views/DeregistrationPropertySpec.scala
@@ -46,7 +46,7 @@ class DeregistrationPropertySpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.VATAccountsController.show().url
     }
 
     s"have the correct page heading" in {
@@ -78,7 +78,7 @@ class DeregistrationPropertySpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.VATAccountsController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/DeregistrationReasonSpec.scala
+++ b/test/views/DeregistrationReasonSpec.scala
@@ -89,7 +89,7 @@ class DeregistrationReasonSpec extends ViewBaseSpec {
     }
 
     "display the correct error heading" in {
-      elementText(Selectors.errorHeading) shouldBe s"${CommonMessages.errorHeading} This field is required"
+      elementText(Selectors.errorHeading) shouldBe s"${CommonMessages.errorHeading} ${CommonMessages.errorMandatoryRadioOption}"
     }
 
     s"have the correct a radio button form with the correct 3 options" in {
@@ -103,7 +103,7 @@ class DeregistrationReasonSpec extends ViewBaseSpec {
     }
 
     "display the correct error messages" in {
-      elementText(Selectors.error) shouldBe "This field is required"
+      elementText(Selectors.error) shouldBe CommonMessages.errorMandatoryRadioOption
     }
   }
 }

--- a/test/views/DeregistrationReasonSpec.scala
+++ b/test/views/DeregistrationReasonSpec.scala
@@ -44,7 +44,7 @@ class DeregistrationReasonSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregisterForVATController.show().url
     }
 
     s"have the correct page heading" in {
@@ -81,7 +81,7 @@ class DeregistrationReasonSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregisterForVATController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/NextTaxableTurnoverSpec.scala
+++ b/test/views/NextTaxableTurnoverSpec.scala
@@ -43,7 +43,7 @@ class NextTaxableTurnoverSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.TaxableTurnoverController.show().url
     }
 
     s"have the correct page heading" in {
@@ -74,7 +74,7 @@ class NextTaxableTurnoverSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.TaxableTurnoverController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/OptionTaxSpec.scala
+++ b/test/views/OptionTaxSpec.scala
@@ -47,7 +47,7 @@ class OptionTaxSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregistrationPropertyController.show().url
     }
 
     s"have the correct page heading" in {
@@ -88,7 +88,7 @@ class OptionTaxSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregistrationPropertyController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/SellCapitalAssetsSpec.scala
+++ b/test/views/SellCapitalAssetsSpec.scala
@@ -46,7 +46,7 @@ class SellCapitalAssetsSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.CapitalAssetsController.show().url
     }
 
     s"have the correct page heading" in {
@@ -82,7 +82,7 @@ class SellCapitalAssetsSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.CapitalAssetsController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/TaxableTurnoverSpec.scala
+++ b/test/views/TaxableTurnoverSpec.scala
@@ -43,7 +43,7 @@ class TaxableTurnoverSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregistrationReasonController.show().url
     }
 
     s"have the correct page heading" in {
@@ -74,7 +74,7 @@ class TaxableTurnoverSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.DeregistrationReasonController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/VATAccountsSpec.scala
+++ b/test/views/VATAccountsSpec.scala
@@ -43,7 +43,7 @@ class VATAccountsSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.CeasedTradingDateController.show().url
     }
 
     s"have the correct page heading" in {
@@ -80,7 +80,7 @@ class VATAccountsSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe "#"
+      element(Selectors.back).attr("href") shouldBe controllers.routes.CeasedTradingDateController.show().url
     }
 
     s"have the correct page heading" in {

--- a/test/views/VATAccountsSpec.scala
+++ b/test/views/VATAccountsSpec.scala
@@ -43,7 +43,7 @@ class VATAccountsSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe controllers.routes.CeasedTradingDateController.show().url
+      element(Selectors.back).attr("href") shouldBe "#"
     }
 
     s"have the correct page heading" in {
@@ -80,7 +80,7 @@ class VATAccountsSpec extends ViewBaseSpec {
 
     s"have the correct back text" in {
       elementText(Selectors.back) shouldBe CommonMessages.back
-      element(Selectors.back).attr("href") shouldBe controllers.routes.CeasedTradingDateController.show().url
+      element(Selectors.back).attr("href") shouldBe "#"
     }
 
     s"have the correct page heading" in {

--- a/test/views/WhyTurnoverBelowSpec.scala
+++ b/test/views/WhyTurnoverBelowSpec.scala
@@ -47,7 +47,7 @@ class WhyTurnoverBelowSpec extends ViewBaseSpec {
 
       s"have the correct back text" in {
         elementText(Selectors.back) shouldBe CommonMessages.back
-        element(Selectors.back).attr("href") shouldBe "#"
+        element(Selectors.back).attr("href") shouldBe controllers.routes.NextTaxableTurnoverController.show().url
       }
 
       s"have the correct page heading" in {


### PR DESCRIPTION
**Note**
  - The delayed Deregistration Date view is always shown as the decision to render it is based on stored answers which can't be retrieved yet
  - Back Links which are not dynamic have been updated as part of this PR