### PR TITLE
Enforced httpOnly on cookies set by play

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,6 +17,7 @@ include "frontend.conf"
 appName = "deregister-vat-frontend"
 application.router = prod.Routes
 application.langs = "en,cy"
+play.i18n.langCookieHttpOnly = true
 
 # Play Modules
 # ~~~~

--- a/test/controllers/LanguageControllerSpec.scala
+++ b/test/controllers/LanguageControllerSpec.scala
@@ -35,14 +35,14 @@ class LanguageControllerSpec extends ControllerBaseSpec {
         lazy val result = controller.switchLanguage("english")(fRequest)
 
         status(result) shouldBe SEE_OTHER
-        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "en", None, "/", None, secure = false, httpOnly = false))
+        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "en", None, "/", None, secure = false, httpOnly = true))
         redirectLocation(result) shouldBe Some("thisIsMyNextLocation")
       }
       "Welsh is passed in" in {
         lazy val result = controller.switchLanguage("cymraeg")(fRequest)
 
         status(result) shouldBe SEE_OTHER
-        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "cy", None, "/", None, secure = false, httpOnly = false))
+        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "cy", None, "/", None, secure = false, httpOnly = true))
         redirectLocation(result) shouldBe Some("thisIsMyNextLocation")
       }
     }
@@ -51,7 +51,7 @@ class LanguageControllerSpec extends ControllerBaseSpec {
         lazy val result = controller.switchLanguage("dovahtongue")(fRequest)
 
         status(result) shouldBe SEE_OTHER
-        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "en", None, "/", None, secure = false, httpOnly = false))
+        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "en", None, "/", None, secure = false, httpOnly = true))
         redirectLocation(result) shouldBe Some("thisIsMyNextLocation")
       }
     }
@@ -62,7 +62,7 @@ class LanguageControllerSpec extends ControllerBaseSpec {
         val expectedResponse = mockConfig.languageFallbackUrl
 
         status(result) shouldBe SEE_OTHER
-        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "en", None, "/", None, secure = false, httpOnly = false))
+        cookies(result).get(Play.langCookieName(messagesApi)) shouldBe Some(Cookie("PLAY_LANG", "en", None, "/", None, secure = false, httpOnly = true))
         redirectLocation(result) shouldBe Some(expectedResponse)
       }
     }


### PR DESCRIPTION
This should fix ZAP test failures in pipeline