### PR TITLE
Service Error Handler fix and added generic welsh error messages

### DIFF
--- a/app/config/ServiceErrorHandler.scala
+++ b/app/config/ServiceErrorHandler.scala
@@ -28,27 +28,11 @@ import scala.concurrent.Future
 class ServiceErrorHandler @Inject()(val messagesApi: MessagesApi,
                                     appConfig: AppConfig) extends FrontendErrorHandler {
 
-  private implicit def rhToRequest(rh: RequestHeader) : Request[_] = Request(rh, "")
-
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)
                                     (implicit request: Request[_]): Html = {
     views.html.errors.standardError(appConfig, pageTitle, heading, message)
   }
 
-  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = exception match {
-    case _ => Future.successful(showInternalServerError(request))
-  }
+  def showInternalServerError(implicit request: Request[_]): Result = InternalServerError(internalServerErrorTemplate)
 
-  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = statusCode match {
-    case _ => Future.successful(showInternalServerError(request))
-  }
-
-  def showInternalServerError(implicit request: Request[_]): Result = {
-    val msgs = request2Messages
-    InternalServerError(standardErrorTemplate(
-      msgs("standardError.title"),
-      msgs("standardError.heading"),
-      msgs("standardError.message")
-    ))
-  }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -23,9 +23,9 @@ common.error.tooManyDecimals = Enter a maximum of 2 decimal places for pence
 common.error.greaterThanMax = You have entered too many numbers
 common.dateRangeSeparator = to
 
-standardError.title = There is a problem with the service - VAT reporting through software - GOV.UK
-standardError.heading = Sorry, there is a problem with the service
-standardError.message = Try again later.
+global.error.InternalServerError500.title = There is a problem with the service - VAT reporting through software - GOV.UK
+global.error.InternalServerError500.heading = Sorry, there is a problem with the service
+global.error.InternalServerError500.message = Try again later.
 
 error.date.invalidCharacters = Enter a date using numbers 0 to 9
 error.date.day = Enter numbers between 1 and 31

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -49,9 +49,15 @@ common.error.tooManyDecimals = Nodwch uchafswm o 2 bwynt degol ar gyfer ceinioga
 common.error.greaterThanMax = Rydych wedi nodi gormod o rifau
 common.dateRangeSeparator = i
 
-standardError.title = Mae problem gyda’r gwasanaeth – Rhoi gwybod am TAW drwy feddalwedd – GOV.UK
-standardError.heading = Mae’n ddrwg gennym – mae problem gyda’r gwasanaeth
-standardError.message = Rhowch gynnig arall arni yn nes ymlaen.
+global.error.InternalServerError500.title = Mae problem gyda’r gwasanaeth – Rhoi gwybod am TAW drwy feddalwedd – GOV.UK
+global.error.InternalServerError500.heading = Mae’n ddrwg gennym – mae problem gyda’r gwasanaeth
+global.error.InternalServerError500.message = Rhowch gynnig arall arni yn nes ymlaen.
+global.error.badRequest400.title = Cais drwg – 400
+global.error.badRequest400.heading = Cais drwg
+global.error.badRequest400.message = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
+global.error.pageNotFound404.title = Heb ddod o hyd i’r dudalen – 404
+global.error.pageNotFound404.heading = Ni ellir dod o hyd i’r dudalen hon
+global.error.pageNotFound404.message = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
 
 error.date.invalidCharacters = Nodwch ddyddiad gan ddefnyddio’r rhifau 0 i 9
 error.date.day = Nodwch rifau rhwng 1 a 31


### PR DESCRIPTION
This branch fixes failing ZAP tests by ensuring the correct error page and HTTP response is returned depending on if the cause is a client or server error.

Before, if a request was made to a non-existent URL, the 500 Internal Server Error page was always returned to the user instead of the appropriate 404 - Not Found as the onClientError method in ServiceErrorHandler was incorrectly overridden. This led to ZAP spider tests failing as it thought the 500s were divulging potentially sensitive server information when it tried to attack random URLs that didn't exist.

There was also no Welsh translation for 400 and 404 errors (these messages sit in frontend-bootstrap which doesn't support welsh versions) so I have added overrides in messages.cy taken from company-auth-frontend (https://github.com/hmrc/company-auth-frontend/blob/84f3f1aa836a8ad674d5ab927b64f346c61fede4/conf/messages.cy#L88). If the language is set to Welsh and a generic error is thrown, Play can now lookup the Welsh version of the messages