### PR TITLE
BTAT-7464 - Iterate the Cancel VAT journey to include Cancellation date on CYA page

### DIFF
--- a/app/models/CheckYourAnswersModel.scala
+++ b/app/models/CheckYourAnswersModel.scala
@@ -173,7 +173,7 @@ case class CheckYourAnswersModel(deregistrationReason: Option[DeregistrationReas
     if(answer.yesNo.value)
       {Html(answer.date.get.longDate())}
     else
-      {Html("No")},
+      {Html(messages("checkYourAnswers.answer.no"))},
     controllers.routes.DeregistrationDateController.show().url,
     messages("checkYourAnswers.hidden.deregistrationDate"),
     "dereg-date"

--- a/app/models/CheckYourAnswersModel.scala
+++ b/app/models/CheckYourAnswersModel.scala
@@ -168,11 +168,14 @@ case class CheckYourAnswersModel(deregistrationReason: Option[DeregistrationReas
     "new-invoices"
   ))
 
-  private val deregDateAnswer = deregDate.flatMap(_.date.map(answer => CheckYourAnswersRowModel(
+  private val deregDateAnswer = deregDate.map(answer => CheckYourAnswersRowModel(
     messages("checkYourAnswers.question.deregistrationDate"),
-    Html(answer.longDate),
+    if(answer.yesNo.value)
+      {Html(answer.date.get.longDate())}
+    else
+      {Html("No")},
     controllers.routes.DeregistrationDateController.show().url,
     messages("checkYourAnswers.hidden.deregistrationDate"),
     "dereg-date"
-  )))
+  ))
 }

--- a/conf/messages
+++ b/conf/messages
@@ -154,6 +154,7 @@ checkYourAnswers.answer.cash = Cash accounting
 checkYourAnswers.answer.reason.ceased = Business stopped trading
 checkYourAnswers.answer.reason.belowThreshold = Annual turnover is below £{0}
 checkYourAnswers.answer.reason.other = Other
+checkYourAnswers.answer.no = No
 checkYourAnswers.confirm = Confirm and cancel VAT registration
 
 deregistrationConfirmation.title = Request to cancel VAT registration received

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -185,6 +185,7 @@ checkYourAnswers.answer.cash = Cyfrifyddu arian parod
 checkYourAnswers.answer.reason.ceased = Busnes wedi rhoi’r gorau i fasnachu
 checkYourAnswers.answer.reason.belowThreshold = Mae’r trosiant blynyddol yn is nag £{0}
 checkYourAnswers.answer.reason.other = Arall
+checkYourAnswers.answer.no = Na
 checkYourAnswers.confirm = Cadarnhau a chanslo cofrestriad TAW
 
 deregistrationConfirmation.title = Cais i ganslo cofrestriad TAW wedi dod i law

--- a/test/assets/constants/CheckYourAnswersTestConstants.scala
+++ b/test/assets/constants/CheckYourAnswersTestConstants.scala
@@ -27,7 +27,8 @@ import utils.{MoneyFormatter, TestUtil}
 object CheckYourAnswersTestConstants extends TestUtil {
 
   val dateModel = DateModel(1,1,2018)
-  val deregistrationDate = DeregistrationDateModel(Yes,Some(DateModel(1,1,2018)))
+  val deregistrationDateYes = DeregistrationDateModel(Yes,Some(DateModel(1,1,2018)))
+  val deregistrationDateNo = DeregistrationDateModel(No,None)
 
   val deregReasonRow = CheckYourAnswersRowModel(
     CheckYourAnswersMessages.reason,
@@ -180,9 +181,17 @@ object CheckYourAnswersTestConstants extends TestUtil {
     "new-invoices"
   )
 
-  val deregDateRow = CheckYourAnswersRowModel(
+  val deregDateRowYes = CheckYourAnswersRowModel(
     CheckYourAnswersMessages.deregistrationDate,
-    Html(deregistrationDate.date.get.longDate),
+    Html(deregistrationDateYes.date.get.longDate),
+    controllers.routes.DeregistrationDateController.show().url,
+    CheckYourAnswersMessages.deregistrationDateHidden,
+    "dereg-date"
+  )
+
+  val deregDateRowNo = CheckYourAnswersRowModel(
+    CheckYourAnswersMessages.deregistrationDate,
+    Html("No"),
     controllers.routes.DeregistrationDateController.show().url,
     CheckYourAnswersMessages.deregistrationDateHidden,
     "dereg-date"

--- a/test/controllers/CheckAnswersControllerSpec.scala
+++ b/test/controllers/CheckAnswersControllerSpec.scala
@@ -62,7 +62,7 @@ class CheckAnswersControllerSpec extends ControllerBaseSpec with MockCheckAnswer
               Some(yesNoAmountNo),
               Some(Yes),
               Some(Yes),
-              Some(deregistrationDate)
+              Some(deregistrationDateYes)
             )
           ))
           mockAuthResult(Future.successful(mockAuthorisedIndividual))

--- a/test/models/CheckYourAnswersModelSpec.scala
+++ b/test/models/CheckYourAnswersModelSpec.scala
@@ -41,7 +41,7 @@ class CheckYourAnswersModelSpec extends TestUtil {
           Some(stocksModel),
           Some(Yes),
           Some(Yes),
-          Some(deregistrationDate)
+          Some(deregistrationDateYes)
         ).seqAnswers shouldBe
           Seq(
             deregReasonRow,
@@ -58,7 +58,7 @@ class CheckYourAnswersModelSpec extends TestUtil {
             stocksValueRow,
             newInvoicesRow,
             outstandingInvoicesRow,
-            deregDateRow
+            deregDateRowYes
           )
       }
 
@@ -77,7 +77,7 @@ class CheckYourAnswersModelSpec extends TestUtil {
             Some(yesNoAmountNo),
             Some(Yes),
             Some(Yes),
-            Some(deregistrationDate)
+            Some(deregistrationDateYes)
           ).seqAnswers shouldBe
             Seq(
               deregReasonRow,
@@ -91,7 +91,7 @@ class CheckYourAnswersModelSpec extends TestUtil {
               stocksRowNo,
               newInvoicesRow,
               outstandingInvoicesRow,
-              deregDateRow
+              deregDateRowYes
             )
         }
       }
@@ -111,7 +111,7 @@ class CheckYourAnswersModelSpec extends TestUtil {
             Some(yesNoAmountNo),
             Some(Yes),
             Some(Yes),
-            Some(deregistrationDate)
+            Some(deregistrationDateYes)
           ).seqAnswers shouldBe
             Seq(
               deregReasonRow,
@@ -125,7 +125,41 @@ class CheckYourAnswersModelSpec extends TestUtil {
               stocksRowNo,
               newInvoicesRow,
               outstandingInvoicesRow,
-              deregDateRow
+              deregDateRowYes
+            )
+        }
+      }
+
+      "given an answer of 'no' for deregistrationDate" should{
+
+        "return a sequence containing the deregistrationDate row with a value of 'No'" in {
+          CheckYourAnswersModel(
+            Some(Ceased),
+            Some(dateModel),
+            Some(Yes),
+            Some(nextTaxableTurnoverBelow),
+            Some(whyTurnoverBelowMin),
+            Some(StandardAccounting),
+            Some(yesNoAmountNo),
+            Some(yesNoAmountNo),
+            Some(yesNoAmountNo),
+            Some(Yes),
+            Some(Yes),
+            Some(deregistrationDateNo)
+          ).seqAnswers shouldBe
+            Seq(
+              deregReasonRow,
+              ceasedTradingRow,
+              taxableTurnoverRow(mockConfig.thresholdString),
+              nextTaxableTurnoverRow,
+              whyBelowRowMin,
+              vatAccountsRow,
+              optionTaxRowNo,
+              captialAssetsRowNo,
+              stocksRowNo,
+              newInvoicesRow,
+              outstandingInvoicesRow,
+              deregDateRowNo
             )
         }
       }

--- a/test/services/CheckAnswersServiceSpec.scala
+++ b/test/services/CheckAnswersServiceSpec.scala
@@ -66,7 +66,7 @@ class CheckAnswersServiceSpec extends TestUtil with MockDeregReasonAnswerService
         setupMockGetStocks(Right(Some(stocksModel)))
         setupMockGetIssueNewInvoices(Right(Some(Yes)))
         setupMockGetOutstandingInvoices(Right(Some(Yes)))
-        setupMockGetDeregDate(Right(Some(deregistrationDate)))
+        setupMockGetDeregDate(Right(Some(deregistrationDateYes)))
 
         await(TestCheckAnswersService.checkYourAnswersModel()) shouldBe Right(
           CheckYourAnswersModel(
@@ -81,7 +81,7 @@ class CheckAnswersServiceSpec extends TestUtil with MockDeregReasonAnswerService
             Some(stocksModel),
             Some(Yes),
             Some(Yes),
-            Some(deregistrationDate)
+            Some(deregistrationDateYes)
           )
         )
       }


### PR DESCRIPTION
# Pull Request Checklist
* [ ] Branch is rebased with master
* [ ] Added Unit Tests for changed functionality
* [ ] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [change-vat-acceptance-tests](https://github.com/hmrc/change-vat-acceptance-tests) (see README of repo)
* [ ] Ran [change-vat-performance-tests](https://github.com/hmrc/change-vat-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
