### PR TITLE
BTAT-7511 Bug fix: Updated end of dereg journey to prevent going back…

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -21,4 +21,5 @@ object SessionKeys {
   val CLIENT_VRN: String = "CLIENT_VRN"
   val verifiedAgentEmail: String = "verifiedAgentEmail"
   val pendingDeregKey: String = "pendingDeregistration"
+  val deregSuccessful: String = "successfulDeregistration"
 }

--- a/app/controllers/CheckAnswersController.scala
+++ b/app/controllers/CheckAnswersController.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import common.SessionKeys
 import config.{AppConfig, ServiceErrorHandler}
 import controllers.predicates.{AuthPredicate, PendingChangesPredicate}
 import javax.inject.{Inject, Singleton}
@@ -52,6 +53,8 @@ class CheckAnswersController @Inject()(val messagesApi: MessagesApi,
   val submit: Action[AnyContent] = authenticate.async { implicit user =>
     updateDeregistrationService.updateDereg.map {
       case Right(VatSubscriptionSuccess) => Redirect(controllers.routes.DeregistrationConfirmationController.show().url)
+          .addingToSession(SessionKeys.deregSuccessful -> "true", SessionKeys.pendingDeregKey -> "true")
+
       case Left(error) =>
         Logger.warn("[CheckAnswersController][submit] - error returned from vat subscription when updating dereg: " + error.message)
         serviceErrorHandler.showInternalServerError

--- a/it/pages/DeregistrationConfirmationISpec.scala
+++ b/it/pages/DeregistrationConfirmationISpec.scala
@@ -28,7 +28,7 @@ import play.api.test.Helpers.OK
 
 class DeregistrationConfirmationISpec extends IntegrationBaseSpec {
 
-  val session: Map[String, String] = Map(SessionKeys.CLIENT_VRN -> vrn)
+  val session: Map[String, String] = Map(SessionKeys.CLIENT_VRN -> vrn, SessionKeys.deregSuccessful -> "true")
   lazy val mockAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
 
   override def beforeEach() {

--- a/test/controllers/CheckAnswersControllerSpec.scala
+++ b/test/controllers/CheckAnswersControllerSpec.scala
@@ -20,6 +20,7 @@ import assets.constants.CheckYourAnswersTestConstants._
 import assets.constants.NextTaxableTurnoverTestConstants._
 import assets.constants.WhyTurnoverBelowTestConstants._
 import assets.constants.YesNoAmountTestConstants._
+import common.SessionKeys
 import models._
 import play.api.http.Status
 import play.api.test.Helpers.{contentType, _}
@@ -84,7 +85,6 @@ class CheckAnswersControllerSpec extends ControllerBaseSpec with MockCheckAnswer
         }
       }
 
-
       "No deregistration date for DeregDateAnswerService is returned" should {
 
         lazy val result = TestCheckAnswersController.show()(request)
@@ -144,7 +144,7 @@ class CheckAnswersControllerSpec extends ControllerBaseSpec with MockCheckAnswer
 
         lazy val result = TestCheckAnswersController.submit()(request)
 
-        "return 200 (OK)" in {
+        "return 303 (see other)" in {
           setupUpdateDeregistration(Right(VatSubscriptionSuccess))
           mockAuthResult(Future.successful(mockAuthorisedIndividual))
           status(result) shouldBe Status.SEE_OTHER
@@ -152,6 +152,13 @@ class CheckAnswersControllerSpec extends ControllerBaseSpec with MockCheckAnswer
 
         "redirect to the correct page" in {
           redirectLocation(result) shouldBe Some(controllers.routes.DeregistrationConfirmationController.show().url)
+        }
+        "add the pending dereg value to the session" in {
+        session(result).get(SessionKeys.pendingDeregKey) shouldBe Some("true")
+        }
+
+        "add the successful dereg value to the session" in {
+          session(result).get(SessionKeys.deregSuccessful) shouldBe Some("true")
         }
       }
 


### PR DESCRIPTION
… through journey & added redirect

# Pull Request Checklist
* [X ] Branch is rebased with master
* [X] Added Unit Tests for changed functionality
* [X] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [X] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [X] Ran [change-vat-acceptance-tests](https://github.com/hmrc/change-vat-acceptance-tests) (see README of repo)
* [ ] Ran [change-vat-performance-tests](https://github.com/hmrc/change-vat-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests

Redirect added to prevent users from going directly to:
/vat-through-software/account/deregister/deregister-request-received

