### PR TITLE
[BTAT-8198] - disabled JUnitXmlReportPlugin in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] = tests map {
 
 lazy val microservice: Project = Project(appName, file("."))
   .enablePlugins(Seq(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
+  .disablePlugins(JUnitXmlReportPlugin)
   .settings(PlayKeys.playDefaultPort := 9153)
   .settings(coverageSettings: _*)
   .settings(playSettings: _*)


### PR DESCRIPTION
# Pull Request Checklist
* [ ] Branch is rebased with master
* [ ] Added Unit Tests for changed functionality
* [ ] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [change-vat-acceptance-tests](https://github.com/hmrc/change-vat-acceptance-tests) (see README of repo)
* [ ] Ran [change-vat-performance-tests](https://github.com/hmrc/change-vat-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
