### PR TITLE
Added menu toggle fix CSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,3 +34,10 @@ $hmrc-assets-path: "/vat-through-software/account/cancel-vat/assets/lib/hmrc-fro
   background:#28a197;
   text-align:center;
 }
+
+.js-enabled .govuk-header__menu-button {
+  display: none;
+}
+.js-enabled .govuk-header__navigation {
+  display: block;
+}


### PR DESCRIPTION
This was missed in the initial govuk assets upgrade and even though it's a very small issue it's something we know can be picked up by an a11y audit.