### PR TITLE
[BTAT-9394] Allow users to enter pound sign in currency inputs

### DIFF
--- a/app/forms/NextTaxableTurnoverForm.scala
+++ b/app/forms/NextTaxableTurnoverForm.scala
@@ -30,7 +30,7 @@ object NextTaxableTurnoverForm extends FormValidation {
         .verifying("taxableTurnover.error.mandatory", _.isDefined)
         .transform[String](x => x.get, x => Some(x))
         .verifying(isNumericConstraint("taxableTurnover.error.nonNumeric"), hasMaxTwoDecimalsConstraint("common.error.tooManyDecimals"))
-        .transform[BigDecimal](x => BigDecimal(x), x => x.toString)
+        .transform[BigDecimal](x => BigDecimal(x.stripPrefix("£")), x => x.toString)
         .verifying(isPositive("common.error.negative"), doesNotExceed(maxAmount, "common.error.tooManyDigitsBeforeDecimal"))
     )(NumberInputModel.apply)(NumberInputModel.unapply)
   )

--- a/app/forms/YesNoAmountForm.scala
+++ b/app/forms/YesNoAmountForm.scala
@@ -40,7 +40,7 @@ object YesNoAmountForm extends FormValidation {
       (data.get(yesNo), data.get(key)) match {
         case (Some(a), Some(x)) if a == yes && (x.trim == "") => Left(Seq(FormError(key, emptyAmount)))
         case (Some(a), Some(x)) if a == yes && (!isNumeric(x)) => Left(Seq(FormError(key, "common.error.mandatoryAmount")))
-        case (Some(a), Some(x)) if a == yes => validateAmount(key)(BigDecimal(x))
+        case (Some(a), Some(x)) if a == yes => validateAmount(key)(BigDecimal(x.stripPrefix("£")))
         case _ => Right(None)
       }
     }

--- a/app/forms/ZeroRatedSuppliesForm.scala
+++ b/app/forms/ZeroRatedSuppliesForm.scala
@@ -30,7 +30,7 @@ object ZeroRatedSuppliesForm extends FormValidation {
         .verifying("zeroRatedSupplies.error.mandatory", _.isDefined)
         .transform[String](x => x.get, x => Some(x))
         .verifying(isNumericConstraint("zeroRatedSupplies.error.nonNumeric"), hasMaxTwoDecimalsConstraint("common.error.tooManyDecimals"))
-        .transform[BigDecimal](x => BigDecimal(x), x => x.toString)
+        .transform[BigDecimal](x => BigDecimal(x.stripPrefix("£")), x => x.toString)
         .verifying(isPositive("common.error.negative"), doesNotExceed(maxAmount, "common.error.tooManyDigitsBeforeDecimal"))
     )(NumberInputModel.apply)(NumberInputModel.unapply)
   )

--- a/app/forms/utils/FormValidation.scala
+++ b/app/forms/utils/FormValidation.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
 
 trait FormValidation {
 
-  val isNumeric: String => Boolean = amt => Try(BigDecimal(amt)) match {
+  val isNumeric: String => Boolean = amt => Try(BigDecimal(amt.stripPrefix("£"))) match {
     case Success(_) => true
     case _ => false
   }

--- a/test/forms/NextTaxableTurnoverFormSpec.scala
+++ b/test/forms/NextTaxableTurnoverFormSpec.scala
@@ -26,14 +26,14 @@ class NextTaxableTurnoverFormSpec extends TestUtil {
 
   "Binding a form with valid data" should {
 
-    val data = Map("amount" -> "1000.01")
+    val data = Map("amount" -> "£1000.01")
     val form = NextTaxableTurnoverForm.taxableTurnoverForm.bind(data)
 
     "result in a form with no errors" in {
       form.hasErrors shouldBe false
     }
 
-    "generate the correct model" in {
+    "strip the pound sign and generate the correct model" in {
       form.value shouldBe Some(NumberInputModel(BigDecimal(1000.01)))
     }
   }

--- a/test/forms/YesNoAmountFormSpec.scala
+++ b/test/forms/YesNoAmountFormSpec.scala
@@ -28,7 +28,7 @@ class YesNoAmountFormSpec extends TestUtil {
 
     val data = Map(
       "yes_no" -> "yes",
-      "amount" -> "1000.01"
+      "amount" -> "£1000.01"
     )
     val form = YesNoAmountForm.yesNoAmountForm("yesNoError", "emptyAmount").bind(data)
 
@@ -36,7 +36,7 @@ class YesNoAmountFormSpec extends TestUtil {
       form.hasErrors shouldBe false
     }
 
-    "generate a YesNoAmountModel" in {
+    "strip the pound sign and generate a YesNoAmountModel" in {
       form.value shouldBe Some(YesNoAmountModel(Yes,Some(BigDecimal(1000.01))))
     }
   }

--- a/test/forms/ZeroRatedSuppliesFormSpec.scala
+++ b/test/forms/ZeroRatedSuppliesFormSpec.scala
@@ -26,14 +26,14 @@ class ZeroRatedSuppliesFormSpec  extends TestUtil{
 
   "Binding a form with valid data" should {
 
-    val data = Map("amount" -> "1000.01")
+    val data = Map("amount" -> "£1000.01")
     val form = ZeroRatedSuppliesForm.zeroRatedSuppliesForm.bind(data)
 
     "result in a form with no errors" in {
       form.hasErrors shouldBe false
     }
 
-    "generate the correct model" in {
+    "strip the pound sign and generate the correct model" in {
       form.value shouldBe Some(NumberInputModel(BigDecimal(1000.01)))
     }
   }


### PR DESCRIPTION
# Pull Request Checklist
* [x] Branch is rebased with master
* [x] Added Unit Tests for changed functionality
* [x] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [x] Ran [change-vat-acceptance-tests](https://github.com/hmrc/change-vat-acceptance-tests) (see README of repo)
* [ ] Ran [change-vat-performance-tests](https://github.com/hmrc/change-vat-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
