### PR TITLE
BTAT-10606 Audit of message files

### DIFF
--- a/app/testOnly/views/FeatureSwitch.scala.html
+++ b/app/testOnly/views/FeatureSwitch.scala.html
@@ -21,7 +21,7 @@
 
 @(form: Form[FeatureSwitchModel])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
-@mainTemplate(pageTitle = messages("featureSwitch.title")) {
+@mainTemplate(pageTitle = "Feature switches") {
 
   @formWithCSRF(action = testOnly.controllers.routes.FeatureSwitchController.submitFeatureSwitch) {
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import play.core.PlayVersion
 import play.sbt.routes.RoutesKeys
 import sbt.Tests.{Group, SubProcess}
 import uk.gov.hmrc.DefaultBuildSettings._
@@ -52,20 +51,14 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 val compile: Seq[ModuleID] = Seq(
   ws,
   "uk.gov.hmrc"   %% "bootstrap-frontend-play-28"      % "5.24.0",
-  "uk.gov.hmrc"   %% "play-language"                   % "5.3.0-play-28",
   "uk.gov.hmrc"   %% "play-frontend-hmrc"              % "3.21.0-play-28",
   "org.typelevel" %% "cats"                            % "0.9.0"
 )
 
 def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-  "org.scalatest"           %% "scalatest"                    % "3.2.10"             % scope,
-  "org.pegdown"             %  "pegdown"                      % "1.6.0"             % scope,
+  "uk.gov.hmrc"             %% "bootstrap-test-play-28"       % "5.24.0",
   "org.jsoup"               %  "jsoup"                        % "1.13.1"            % scope,
-  "com.typesafe.play"       %% "play-test"                    % PlayVersion.current % scope,
-  "org.scalatestplus.play"  %% "scalatestplus-play"           % "5.1.0"             % scope,
-  "org.scalamock"           %% "scalamock-scalatest-support"  % "3.6.0"             % scope,
-  "com.github.tomakehurst"  %  "wiremock-jre8"                % "2.27.2"            % scope,
-  "com.vladsch.flexmark"    %  "flexmark-all"                 % "0.62.2"            % scope
+  "org.scalamock"           %% "scalamock-scalatest-support"  % "3.6.0"             % scope
 )
 
 def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] = tests map {

--- a/conf/messages
+++ b/conf/messages
@@ -37,14 +37,13 @@ common.error.tooManyDigitsBeforeDecimal = Enter a maximum of 13 decimal places f
 common.dateRangeSeparator = to
 common.pageTitle = {0} - {1} - GOV.UK
 
-global.error.InternalServerError500.title = There is a problem with the service - VAT - GOV.UK
+global.error.InternalServerError500.title = There is a problem with the service
 global.error.InternalServerError500.heading = Sorry, there is a problem with the service
 global.error.InternalServerError500.message = Try again later.
 
 error.date.day = Enter the day in the correct format
 error.date.month = Enter the month in the correct format
 error.date.year = Enter the year in the correct format
-
 
 deregisterForVAT.title = Cancel VAT registration
 deregisterForVAT.p1 = To cancel the registration, you need to know the value of any:
@@ -220,8 +219,6 @@ sessionTimeout.helpThree = using your Government Gateway ID.
 unauthorised.client.title = You can’t use this service yet
 unauthorised.client.useThisService = You need to
 unauthorised.client.signUp = sign up to use software to submit your VAT Returns
-
-featureSwitch.title = Feature switches
 
 outstandingInvoice.title = Will the business receive payment for outstanding invoices after you cancel the registration?
 outstandingInvoice.error.mandatoryRadioOption = Select yes if the business is expecting to receive payment for outstanding invoices after you cancel the registration

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -35,16 +35,11 @@ common.error.negative = Nodwch swm positif
 common.error.tooManyDecimals = Nodwch uchafswm o 2 bwynt degol ar gyfer ceiniogau
 common.error.tooManyDigitsBeforeDecimal = Nodwch uchafswm o 13 lle degol ar gyfer punnoedd
 common.dateRangeSeparator = i
+common.pageTitle = {0} - {1} - GOV.UK
 
-global.error.InternalServerError500.title = Mae problem gyda’r gwasanaeth – TAW - GOV.UK
+global.error.InternalServerError500.title = Mae problem gyda’r gwasanaeth
 global.error.InternalServerError500.heading = Mae’n ddrwg gennym, mae problem gyda’r gwasanaeth
 global.error.InternalServerError500.message = Rhowch gynnig arall arni yn nes ymlaen.
-global.error.badRequest400.title = Cais drwg – 400
-global.error.badRequest400.heading = Cais drwg
-global.error.badRequest400.message = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
-global.error.pageNotFound404.title = Heb ddod o hyd i’r dudalen – 404
-global.error.pageNotFound404.heading = Ni ellir dod o hyd i’r dudalen hon
-global.error.pageNotFound404.message = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
 
 error.date.day = Nodwch y diwrnod yn y fformat cywir
 error.date.month = Nodwch y mis yn y fformat cywir
@@ -224,8 +219,6 @@ sessionTimeout.helpThree = gan ddefnyddio’ch Dynodydd Defnyddiwr (ID) ar gyfer
 unauthorised.client.title = Ni allwch ddefnyddio’r gwasanaeth hwn eto
 unauthorised.client.useThisService = Mae’n rhaid i chi
 unauthorised.client.signUp = gofrestru i ddefnyddio meddalwedd er mwyn cyflwyno’ch Ffurflenni TAW
-
-featureSwitch.title = Feature switches
 
 outstandingInvoice.title = A fydd y busnes yn cael taliad am anfonebau heb eu setlo ar ôl i chi ganslo’r cofrestriad?
 outstandingInvoice.error.mandatoryRadioOption = Dewiswch ‘Iawn’ os yw’r busnes yn disgwyl cael taliad am anfonebau heb eu setlo ar ôl i chi ganslo’r cofrestriad


### PR DESCRIPTION
We had no custom English messages for the default bootstrap bad request or not found pages, so I removed the Welsh messages for those after confirming that bootstrap had Welsh in place.

Fixed a small bug where the generic 500 messages would list the `- VAT - GOV.UK` twice.